### PR TITLE
Added trackBy function to prevent destroy/init

### DIFF
--- a/src/app/components/resource/resource.component.html
+++ b/src/app/components/resource/resource.component.html
@@ -62,8 +62,8 @@
           <strong>Actions</strong>
         </div>
       </div>
-      <div *ngFor="let language of resourcesComponent.languages">
-        <admin-translation [language]="language" [resourceComponent]="this"></admin-translation>
+      <div *ngFor="let language of resourcesComponent.languages"> 
+        <admin-translation [language]="language" [resource]="resource" [translationLoaded]="translationLoaded$" (loadResources)="onLoadResources()"></admin-translation>
       </div>
     </div>
   </div>

--- a/src/app/components/resource/resource.component.ts
+++ b/src/app/components/resource/resource.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnInit} from '@angular/core';
+import {Component, Input, OnInit, OnChanges, SimpleChanges, OnDestroy} from '@angular/core';
 import {Resource} from '../../models/resource';
 import {Page} from '../../models/page';
 import {NgbModal, NgbModalRef} from '@ng-bootstrap/ng-bootstrap';
@@ -8,21 +8,35 @@ import {LanguageService} from '../../service/language.service';
 import {ResourcesComponent} from '../resources/resources.component';
 import {PageComponent} from '../page/page.component';
 import {CreatePageComponent} from '../create-page/create-page.component';
+import { Subject } from 'rxjs/Subject';
 
 @Component({
   selector: 'admin-resource',
   templateUrl: './resource.component.html'
 })
-export class ResourceComponent implements OnInit {
+export class ResourceComponent implements OnInit, OnChanges, OnDestroy {
   @Input() resource: Resource;
   @Input() resourcesComponent: ResourcesComponent;
 
   private errorMessage: string;
 
+  private _translationLoaded = new Subject<number>();
+  translationLoaded$ = this._translationLoaded.asObservable();
+
   constructor(private languageService: LanguageService, private modalService: NgbModal) {}
 
   ngOnInit(): void {
     this.loadTranslations();
+  }
+
+  ngOnChanges(pChanges: SimpleChanges): void {
+    if (pChanges.resource && pChanges.resource.previousValue && pChanges.resource.currentValue) {
+      this.loadTranslations();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this._translationLoaded.complete();
   }
 
   createPage(): void {
@@ -50,12 +64,17 @@ export class ResourceComponent implements OnInit {
     modalRef.result.then(() => this.resourcesComponent.loadResources(), console.log);
   }
 
+  onLoadResources(): void {
+    this.resourcesComponent.loadResources();
+  }
+
   private loadTranslations(): void {
     this.resource['latest-drafts-translations'].forEach((translation) => {
       this.languageService.getLanguage(translation.language.id, 'custom_pages')
         .then((language) => {
           translation.language = language;
           translation.is_published = translation['is-published'];
+          setTimeout(() => {this._translationLoaded.next(translation.language.id); }, 0);
         })
         .catch(this.handleError.bind(this));
     });

--- a/src/app/components/resources/resources.component.html
+++ b/src/app/components/resources/resources.component.html
@@ -38,7 +38,7 @@
   {{errorMessage}}
 </ngb-alert>
 <div *ngIf="!loadingLanguages">
-  <div *ngFor="let resource of resources">
+  <div *ngFor="let resource of resources;trackBy: trackByFunction">
     <admin-resource [resource]="resource" [resourcesComponent]="this"></admin-resource>
   </div>
 </div>

--- a/src/app/components/resources/resources.component.ts
+++ b/src/app/components/resources/resources.component.ts
@@ -41,6 +41,13 @@ export class ResourcesComponent implements OnInit {
     modalRef.result.then(() => this.loadResources(), console.log);
   }
 
+  trackByFunction(pIx: number, pItem: Resource) {
+    if (!pItem || pIx < 0) {
+      return null;
+    }
+    return pItem.id;
+  }
+
   private loadLanguages(): void {
     this.loadingLanguages = true;
 

--- a/src/app/components/translation/translation.component.html
+++ b/src/app/components/translation/translation.component.html
@@ -69,7 +69,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr *ngFor="let page of getPages()" [ngSwitch]="page['_type']">
+        <tr *ngFor="let page of getPages();trackBy: pagesTrackBy" [ngSwitch]="page['_type']">
           <td>{{getBasePage(page).filename}}</td>
           <td>
             <div class="container">

--- a/src/app/components/translation/translation.component.spec.ts
+++ b/src/app/components/translation/translation.component.spec.ts
@@ -94,7 +94,7 @@ describe('TranslationComponent', () => {
     comp = fixture.componentInstance;
 
     resourceComponent = new ResourceComponent(null, null);
-    comp.resourceComponent = resourceComponent;
+    comp.translationLoaded = resourceComponent.translationLoaded$;
 
     const pageWithCustomPage = buildPage(2);
 
@@ -110,13 +110,13 @@ describe('TranslationComponent', () => {
     const resource = new Resource();
     resource.pages = [ buildPage(1), pageWithCustomPage ];
     resource['custom-manifests'] = [buildCustomManifest(12, language, resource)];
-    comp.resourceComponent.resource = resource;
+    comp.resource = resource;
   });
 
   describe('language does not have existing translations', () => {
     beforeEach(() => {
-      comp.resourceComponent.resource['latest-drafts-translations'] = [];
-
+      comp.resource['latest-drafts-translations'] = [];
+      comp.reloadTranslation();
       fixture.detectChanges();
     });
 
@@ -138,11 +138,11 @@ describe('TranslationComponent', () => {
       translation = new Translation();
       translation.is_published = false;
       translation.language = language;
-      translation.resource = comp.resourceComponent.resource;
+      translation.resource = comp.resource;
 
-      comp.resourceComponent.resource.translations = [translation];
-      comp.resourceComponent.resource['latest-drafts-translations'] = [ translation ];
-
+      comp.resource.translations = [translation];
+      comp.resource['latest-drafts-translations'] = [ translation ];
+      comp.reloadTranslation();
       fixture.detectChanges();
     });
 

--- a/src/app/components/translation/translation.component.ts
+++ b/src/app/components/translation/translation.component.ts
@@ -186,12 +186,10 @@ export class TranslationComponent implements OnInit, OnChanges {
   }
 
   private getCustomManifest(): CustomManifest {
-    // console.log(this.resourceComponent.resource['custom-manifests']);
     return this.resource['custom-manifests'].find(m => m.language.id === this.language.id);
   }
 
   private loadAllResources() {
-    // this.resourceComponent.resourcesComponent.loadResources();
     this.loadResources.emit();
   }
 


### PR DESCRIPTION
[JIRA Task](https://jira.cru.org/browse/GT-754)

- There are 3 components (resources, resource, and translation) used for building the translations page. 
- The resources component is the root component. It loads all the resources from the API and creates a resource component for each resource item received.
- The resource component is the root of translation components.  A resource component instance creates a translation component for each of the language items inside the resource item that the instance is built for.

After any change at the resources component or at a resource component or at a language component, the root component's (resources component) method for refreshing the resource data is triggered. 

When the resource data is refreshed, the source data array that generates the resource components is also altered and the resource components that were built for the previous version of the resource data array is destroyed and rebuilt. Therefore, the UI elements are removed from the web view and re-rendered with the new data even if most of the resource items in the source data array is not changed.

To prevent this behavior, I added a "trackBy" function to the ngFor loop that generates the resource components. This function prevents the components to be removed and re-added whenever the data that the component is built for is not removed from the source array.

Even if a resource component is not removed and re-added, the component can still get the updated version of the resource data that the component is built for.

You can test this by logging in to the app from 2 different browsers:

- Step 1: Edit a resource item's (eg. Emoji Survey) name from browser 1
- Step 2: Edit another resource item's (eg. Free From Fear) name from browser 2
- Step 3: When the resource is updated at browser 2, all resources will be reloaded, the UI will not be refreshed but you'll see the updated name for Emoji Survey resource.
