### PR TITLE
GT-1357 Add a download translation button

### DIFF
--- a/src/app/components/translation/translation.component.html
+++ b/src/app/components/translation/translation.component.html
@@ -42,6 +42,13 @@
       <button (click)="openResourceLanguage()" class="btn btn-primary">
         <i class="fa fa-pencil"></i> Details
       </button>
+      <a
+        [href]="baseDownloadUrl + translation.id"
+        class="btn btn-success"
+        *ngIf="translation.is_published"
+      >
+        <i class="fa fa-download"></i> Download
+      </a>
       <button
         *ngIf="!translation.is_published && !translation.none"
         type="button"

--- a/src/app/components/translation/translation.component.ts
+++ b/src/app/components/translation/translation.component.ts
@@ -28,6 +28,7 @@ import { CustomManifestComponent } from '../custom-manifest/custom-manifest.comp
 import { Resource } from '../../models/resource';
 import { Observable } from 'rxjs';
 import { getLatestTranslation } from './utilities';
+import { environment } from '../../../environments/environment';
 
 @Component({
   selector: 'admin-translation',
@@ -41,6 +42,7 @@ export class TranslationComponent implements OnInit, OnChanges {
 
   translation: Translation;
   customManifest: CustomManifest;
+  baseDownloadUrl = environment.base_url + 'translations/';
 
   saving = false;
   publishing = false;


### PR DESCRIPTION
This adds a button to download a currently published translation. This is useful for debugging parsing of tools.