### PR TITLE
Reduce translations data loaded from the API

### DIFF
--- a/src/app/components/multiple-draft-generator/multiple-draft-generator.component.spec.ts
+++ b/src/app/components/multiple-draft-generator/multiple-draft-generator.component.spec.ts
@@ -52,7 +52,6 @@ describe('MultipleDraftGeneratorComponent', () => {
 
     const r = new Resource();
     r['latest-drafts-translations'] = translations;
-    r.translations = translations;
     comp.resource = r;
 
     fixture.detectChanges();

--- a/src/app/components/multiple-draft-generator/multiple-draft-generator.component.ts
+++ b/src/app/components/multiple-draft-generator/multiple-draft-generator.component.ts
@@ -25,7 +25,7 @@ export class MultipleDraftGeneratorComponent {
   ) {}
 
   showConfirmAlert(): void {
-    this.translations = this.resource.translations.filter(
+    this.translations = this.resource['latest-drafts-translations'].filter(
       (translation) => translation.generateDraft,
     );
     if (this.translations.length === 0) {

--- a/src/app/components/resources/resources.component.spec.ts
+++ b/src/app/components/resources/resources.component.spec.ts
@@ -62,7 +62,7 @@ describe('ResourcesComponent', () => {
 
     setTimeout(() => {
       expect(resourceServiceStub.getResources).toHaveBeenCalledWith(
-        'translations,pages,custom-manifests,tips,attachments,variants',
+        'latest-drafts-translations,pages,custom-manifests,tips,attachments,variants',
       );
 
       done();

--- a/src/app/components/resources/resources.component.ts
+++ b/src/app/components/resources/resources.component.ts
@@ -35,7 +35,7 @@ export class ResourcesComponent implements OnInit {
 
     this.resourceService
       .getResources(
-        'translations,pages,custom-manifests,tips,attachments,variants',
+        'latest-drafts-translations,pages,custom-manifests,tips,attachments,variants',
       )
       .then((resources) => {
         this.resources = resources;

--- a/src/app/components/translation/translation.component.spec.ts
+++ b/src/app/components/translation/translation.component.spec.ts
@@ -163,7 +163,6 @@ describe('TranslationComponent', () => {
       translation.language = language;
       translation.resource = comp.resource;
 
-      comp.resource.translations = [translation];
       comp.resource['latest-drafts-translations'] = [translation];
       comp.reloadTranslation();
       fixture.detectChanges();

--- a/src/app/models/resource.ts
+++ b/src/app/models/resource.ts
@@ -19,7 +19,7 @@ export class Resource {
   metatool?: Resource;
   variants: Resource[];
   'default-variant'?: Resource;
-  translations: Translation[];
+  'latest-drafts-translations': Translation[];
   attachments: Attachment[];
   pages: Page[];
   tips: Tip[];

--- a/src/app/service/resource/resource.service.ts
+++ b/src/app/service/resource/resource.service.ts
@@ -27,17 +27,6 @@ export class ResourceService extends AbstractService {
       .catch(this.handleError);
   }
 
-  getResource(id: number, include: string): Promise<Resource> {
-    const url = `${this.resourcesUrl}/${id}?include=${include}`;
-    return this.http
-      .get(url)
-      .toPromise()
-      .then(function (response) {
-        return new JsonApiDataStore().sync(response.json());
-      })
-      .catch(this.handleError);
-  }
-
   create(resource: Resource): Promise<Resource> {
     return this.http
       .post(


### PR DESCRIPTION
- remove unused getResource() service method
- only load the latest-drafts-translations from the API
