### PR TITLE
Adding new async publish feature for single and bulk.

### DIFF
--- a/src/app/components/multiple-draft-generator/multiple-draft-generator.component.css
+++ b/src/app/components/multiple-draft-generator/multiple-draft-generator.component.css
@@ -7,3 +7,11 @@
 .toggle-drafts label.btn {
   flex: 0 1 50%;
 }
+
+.translation-btn {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 350px;
+  margin: 0 auto 8px;
+}

--- a/src/app/components/multiple-draft-generator/multiple-draft-generator.component.css
+++ b/src/app/components/multiple-draft-generator/multiple-draft-generator.component.css
@@ -1,0 +1,9 @@
+.toggle-drafts {
+  width: 100%;
+  display: flex;
+  margin-bottom: 15px;
+}
+
+.toggle-drafts label.btn {
+  flex: 0 1 50%;
+}

--- a/src/app/components/multiple-draft-generator/multiple-draft-generator.component.html
+++ b/src/app/components/multiple-draft-generator/multiple-draft-generator.component.html
@@ -1,10 +1,44 @@
 <div class="modal-body">
-  <h5>Languages without a Draft</h5>
+  <div class="btn-group btn-group-toggle toggle-drafts" data-toggle="buttons">
+    <label
+      class="btn {{
+        languageType === 'published' ? 'btn-success' : 'btn-secondary'
+      }}"
+    >
+      <input
+        type="radio"
+        name="languageType"
+        value="published"
+        [(ngModel)]="languageType"
+        autocomplete="off"
+        checked
+      />
+      Pubblished Languages
+    </label>
+    <label
+      class="btn {{
+        languageType === 'drafts' ? 'btn-success' : 'btn-secondary'
+      }}"
+    >
+      <input
+        type="radio"
+        name="languageType"
+        value="drafts"
+        [(ngModel)]="languageType"
+        autocomplete="off"
+      />
+      Languages with a Draft
+    </label>
+  </div>
+
   <div *ngFor="let translation of resource['latest-drafts-translations']">
     <label
       class="btn-secondary btn-block"
       ngbButtonLabel
-      *ngIf="translation.is_published"
+      *ngIf="
+        (languageType === 'published' && translation['is-published']) ||
+        (languageType === 'drafts' && !translation['is_published'])
+      "
     >
       <input
         type="checkbox"
@@ -15,21 +49,37 @@
     </label>
   </div>
   <br />
-  <ngb-alert type="info" [dismissible]="false" *ngIf="saving">
-    Saving...
+
+  <ngb-alert type="success" [dismissible]="false" *ngIf="sucessfulMessage">
+    {{ sucessfulMessage }}
   </ngb-alert>
-  <ngb-alert type="danger" [dismissible]="false" *ngIf="errorMessage">
-    {{ errorMessage }}
+  <ngb-alert type="info" [dismissible]="false" *ngIf="alertMessage">
+    {{ alertMessage }}
   </ngb-alert>
-  <button class="btn btn-danger" (click)="cancel()">Cancel</button>
-  <button class="btn btn-success" (click)="showConfirmAlert()">
-    Generate drafts
-  </button>
-  <ngb-alert type="danger" [dismissible]="false" *ngIf="confirmMessage">
-    {{ confirmMessage }}
-    <button (click)="generateDrafts()" class="btn btn-dark">Confirm</button>
-    <button (click)="confirmMessage = null" class="btn btn-secondary">
-      Cancel
+  <ngb-alert
+    type="danger"
+    [dismissible]="false"
+    *ngFor="let error of errorMessage"
+  >
+    {{ error }}
+  </ngb-alert>
+
+  <ngb-alert type="info" [dismissible]="false" *ngIf="confirmMessage">
+    <p>{{ confirmMessage }}</p>
+    <div class="btn-toolbar justify-content-between">
+      <button (click)="confirmMessage = null" class="btn btn-danger">
+        Cancel
+      </button>
+      <button (click)="publishOrCreateDrafts()" class="btn btn-success">
+        Confirm
+      </button>
+    </div>
+  </ngb-alert>
+
+  <div class="modal-footer justify-content-between">
+    <button class="btn btn-secondary" (click)="cancel()">Cancel</button>
+    <button class="btn btn-success" (click)="showConfirmAlert()">
+      {{ languageType === 'published' ? 'Generate drafts' : 'Publish drafts' }}
     </button>
-  </ngb-alert>
+  </div>
 </div>

--- a/src/app/components/multiple-draft-generator/multiple-draft-generator.component.html
+++ b/src/app/components/multiple-draft-generator/multiple-draft-generator.component.html
@@ -1,57 +1,54 @@
 <div class="modal-body">
   <div class="btn-group btn-group-toggle toggle-drafts" data-toggle="buttons">
     <label
-      class="btn {{
-        languageType === 'published' ? 'btn-success' : 'btn-secondary'
+      class="btn btn-success {{
+        actionType === 'publish' ? 'btn-success' : 'btn-outline-success'
       }}"
+      (click)="switchActionType('publish')"
     >
-      <input
-        type="radio"
-        name="languageType"
-        value="published"
-        [(ngModel)]="languageType"
-        autocomplete="off"
-        checked
-      />
-      Pubblished Languages
+      Publish Languages
     </label>
     <label
       class="btn {{
-        languageType === 'drafts' ? 'btn-success' : 'btn-secondary'
+        actionType === 'createDrafts'
+          ? 'btn-secondary'
+          : 'btn-outline-secondary'
       }}"
+      (click)="switchActionType('createDrafts')"
     >
-      <input
-        type="radio"
-        name="languageType"
-        value="drafts"
-        [(ngModel)]="languageType"
-        autocomplete="off"
-      />
-      Languages with a Draft
+      Generate Drafts
     </label>
   </div>
 
   <div *ngFor="let translation of resource['latest-drafts-translations']">
     <label
-      class="btn-secondary btn-block"
+      class="btn-outline-secondary btn-block translation-btn"
       ngbButtonLabel
       *ngIf="
-        (languageType === 'published' && translation['is-published']) ||
-        (languageType === 'drafts' && !translation['is_published'])
+        actionType === 'publish' ||
+        (actionType === 'createDrafts' && translation['is-published'])
       "
     >
-      <input
-        type="checkbox"
-        ngbButton
-        [(ngModel)]="translation.generateDraft"
-      />
-      {{ translation.language.name }}
+      <div class="translation-btn-text">
+        <input
+          type="checkbox"
+          ngbButton
+          [(ngModel)]="translation.selectedForAction"
+        />
+        {{ translation.language.name }}
+      </div>
+      <admin-translation-version-badge [translation]="translation">
+      </admin-translation-version-badge>
     </label>
   </div>
   <br />
 
-  <ngb-alert type="success" [dismissible]="false" *ngIf="sucessfulMessage">
-    {{ sucessfulMessage }}
+  <ngb-alert
+    type="success"
+    [dismissible]="true"
+    *ngFor="let successMessage of sucessfulMessages"
+  >
+    {{ successMessage }}
   </ngb-alert>
   <ngb-alert type="info" [dismissible]="false" *ngIf="alertMessage">
     {{ alertMessage }}
@@ -89,7 +86,7 @@
       (click)="showConfirmAlert()"
       [disabled]="disableButtons"
     >
-      {{ languageType === 'published' ? 'Generate drafts' : 'Publish drafts' }}
+      {{ actionType === 'publish' ? 'Publish' : 'Generate drafts' }}
     </button>
   </div>
 </div>

--- a/src/app/components/multiple-draft-generator/multiple-draft-generator.component.html
+++ b/src/app/components/multiple-draft-generator/multiple-draft-generator.component.html
@@ -77,8 +77,18 @@
   </ngb-alert>
 
   <div class="modal-footer justify-content-between">
-    <button class="btn btn-secondary" (click)="cancel()">Cancel</button>
-    <button class="btn btn-success" (click)="showConfirmAlert()">
+    <button
+      class="btn btn-secondary"
+      (click)="cancel()"
+      [disabled]="disableButtons"
+    >
+      Cancel
+    </button>
+    <button
+      class="btn btn-success"
+      (click)="showConfirmAlert()"
+      [disabled]="disableButtons"
+    >
       {{ languageType === 'published' ? 'Generate drafts' : 'Publish drafts' }}
     </button>
   </div>

--- a/src/app/components/multiple-draft-generator/multiple-draft-generator.component.spec.ts
+++ b/src/app/components/multiple-draft-generator/multiple-draft-generator.component.spec.ts
@@ -22,7 +22,7 @@ describe('MultipleDraftGeneratorComponent', () => {
 
   const buildTranslation = (
     isPublished: boolean,
-    generateDraft: boolean,
+    selectedForAction: boolean,
     language: string,
   ) => {
     const l = new Language();
@@ -32,7 +32,7 @@ describe('MultipleDraftGeneratorComponent', () => {
     t.language = l;
     t.is_published = isPublished;
     t['is-published'] = isPublished;
-    t.generateDraft = generateDraft;
+    t.selectedForAction = selectedForAction;
     return t;
   };
 
@@ -61,7 +61,7 @@ describe('MultipleDraftGeneratorComponent', () => {
     const r = new Resource();
     r['latest-drafts-translations'] = translations;
     comp.resource = r;
-    comp.languageType = 'published';
+    comp.actionType = 'publish';
 
     fixture.detectChanges();
   });
@@ -80,7 +80,7 @@ describe('MultipleDraftGeneratorComponent', () => {
       By.directive(NgbAlert),
     );
     expect(alert.nativeElement.textContent).toContain(
-      `${comp.baseConfirmMessage} Chinese, French?`,
+      `Are you sure you want to generate a draft for these languages Chinese, French?`,
     );
   });
 });

--- a/src/app/components/multiple-draft-generator/multiple-draft-generator.component.spec.ts
+++ b/src/app/components/multiple-draft-generator/multiple-draft-generator.component.spec.ts
@@ -15,6 +15,8 @@ import { By } from '@angular/platform-browser';
 import { NgbButtonLabel } from '@ng-bootstrap/ng-bootstrap';
 import { Language } from '../../models/language';
 import { DebugElement } from '@angular/core';
+import { TranslationVersionBadgeComponent } from '../translation/translation-version-badge/translation-version-badge.component';
+import { MessageType } from '../../models/message';
 
 describe('MultipleDraftGeneratorComponent', () => {
   let comp: MultipleDraftGeneratorComponent;
@@ -38,7 +40,10 @@ describe('MultipleDraftGeneratorComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [MultipleDraftGeneratorComponent],
+      declarations: [
+        MultipleDraftGeneratorComponent,
+        TranslationVersionBadgeComponent,
+      ],
       imports: [NgbModule.forRoot(), FormsModule],
       providers: [
         { provide: DraftService },
@@ -66,13 +71,13 @@ describe('MultipleDraftGeneratorComponent', () => {
     fixture.detectChanges();
   });
 
-  it('only shows languages without drafts', () => {
+  it('shows languages with and without drafts', () => {
     expect(
       fixture.debugElement.queryAll(By.directive(NgbButtonLabel)).length,
-    ).toBe(3);
+    ).toBe(4);
   });
 
-  it('confirm message lists all languages', () => {
+  it('shows confirm message to publish selected languages', () => {
     comp.showConfirmAlert();
     fixture.detectChanges();
 
@@ -80,7 +85,33 @@ describe('MultipleDraftGeneratorComponent', () => {
       By.directive(NgbAlert),
     );
     expect(alert.nativeElement.textContent).toContain(
-      `Are you sure you want to generate a draft for these languages Chinese, French?`,
+      `Are you sure you want to publish these languages: Chinese, French?`,
     );
+  });
+
+  it('shows confirm message to create a draft for selected languages', () => {
+    comp.actionType = 'createDrafts';
+    comp.showConfirmAlert();
+    fixture.detectChanges();
+
+    const alert: DebugElement = fixture.debugElement.query(
+      By.directive(NgbAlert),
+    );
+    expect(alert.nativeElement.textContent).toContain(
+      `Are you sure you want to generate a draft for these languages: Chinese, French?`,
+    );
+  });
+
+  describe('Publish languages', () => {
+    it('shows confirm message to publish selected languages', () => {
+      comp.showConfirmAlert();
+      fixture.detectChanges();
+      spyOn(comp, 'renderMessage');
+      comp.publishOrCreateDrafts();
+      expect(comp.renderMessage).toHaveBeenCalledWith(
+        MessageType.success,
+        'Publishing translations...',
+      );
+    });
   });
 });

--- a/src/app/components/multiple-draft-generator/multiple-draft-generator.component.spec.ts
+++ b/src/app/components/multiple-draft-generator/multiple-draft-generator.component.spec.ts
@@ -7,6 +7,8 @@ import {
 import { MultipleDraftGeneratorComponent } from './multiple-draft-generator.component';
 import { FormsModule } from '@angular/forms';
 import { DraftService } from '../../service/draft.service';
+import { LanguageService } from '../../service/language.service';
+import { ResourceService } from '../../service/resource/resource.service';
 import { Resource } from '../../models/resource';
 import { Translation } from '../../models/translation';
 import { By } from '@angular/platform-browser';
@@ -29,6 +31,7 @@ describe('MultipleDraftGeneratorComponent', () => {
     const t = new Translation();
     t.language = l;
     t.is_published = isPublished;
+    t['is-published'] = isPublished;
     t.generateDraft = generateDraft;
     return t;
   };
@@ -37,7 +40,12 @@ describe('MultipleDraftGeneratorComponent', () => {
     TestBed.configureTestingModule({
       declarations: [MultipleDraftGeneratorComponent],
       imports: [NgbModule.forRoot(), FormsModule],
-      providers: [{ provide: DraftService }, { provide: NgbActiveModal }],
+      providers: [
+        { provide: DraftService },
+        { provide: NgbActiveModal },
+        { provide: ResourceService },
+        { provide: LanguageService },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(MultipleDraftGeneratorComponent);
@@ -53,6 +61,7 @@ describe('MultipleDraftGeneratorComponent', () => {
     const r = new Resource();
     r['latest-drafts-translations'] = translations;
     comp.resource = r;
+    comp.languageType = 'published';
 
     fixture.detectChanges();
   });

--- a/src/app/components/multiple-draft-generator/multiple-draft-generator.component.ts
+++ b/src/app/components/multiple-draft-generator/multiple-draft-generator.component.ts
@@ -1,20 +1,44 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy } from '@angular/core';
 import { Resource } from '../../models/resource';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { DraftService } from '../../service/draft.service';
+import { ResourceService } from '../../service/resource/resource.service';
+import { LanguageService } from '../../service/language.service';
 import { Translation } from '../../models/translation';
+import { MessageType } from '../../models/message';
+
+enum LanguageTypeEnum {
+  draft = 'draft',
+  publish = 'publish',
+}
+
+interface PromisePayload {
+  success: boolean;
+  value?: any;
+  error?: string;
+  type: LanguageTypeEnum;
+}
+interface APICall {
+  type: LanguageTypeEnum;
+  translation: Translation;
+}
+
+type LanguagesType = 'published' | 'drafts';
 
 @Component({
   selector: 'admin-multiple-draft-generator',
   templateUrl: './multiple-draft-generator.component.html',
+  styleUrls: ['./multiple-draft-generator.component.css'],
 })
-export class MultipleDraftGeneratorComponent {
+export class MultipleDraftGeneratorComponent implements OnDestroy {
   resource: Resource;
   translations: Translation[];
-
+  languageType: LanguagesType = 'published';
   confirmMessage: string;
-  saving: boolean;
-  errorMessage: string;
+  errorMessage: string[];
+  alertMessage: string;
+  sucessfulMessage: string;
+  checkToEnsureDraftIsPublished: number;
 
   readonly baseConfirmMessage =
     'Are you sure you want to generate a draft for these languages:';
@@ -22,7 +46,26 @@ export class MultipleDraftGeneratorComponent {
   constructor(
     private ngbActiveModal: NgbActiveModal,
     private draftService: DraftService,
+    private resourceService: ResourceService,
+    private languageService: LanguageService,
   ) {}
+
+  ngOnDestroy(): void {
+    clearInterval(this.checkToEnsureDraftIsPublished);
+  }
+
+  renderMessage(type: MessageType, text: string, time?: number) {
+    if (type === MessageType.error) {
+      this.errorMessage = [text];
+      return;
+    }
+    this[`${type}Message`] = text;
+    if (time) {
+      setTimeout(() => {
+        this[`${type}Message`] = '';
+      }, time);
+    }
+  }
 
   showConfirmAlert(): void {
     this.translations = this.resource['latest-drafts-translations'].filter(
@@ -39,21 +82,146 @@ export class MultipleDraftGeneratorComponent {
     this.confirmMessage = `${this.baseConfirmMessage} ${message}?`;
   }
 
-  generateDrafts(): void {
-    this.saving = true;
-    this.errorMessage = null;
+  async publishOrCreateDrafts(): Promise<void> {
+    this.confirmMessage = null;
+    this.errorMessage = [];
+    const promises: APICall[] = [];
 
-    this.translations.forEach((translation, index) => {
-      this.draftService
-        .createDraft(translation)
-        .then(() => {
-          if (index === this.translations.length - 1) {
-            this.ngbActiveModal.close();
+    // Define what promises we will call
+    this.translations.forEach((translation) => {
+      if (translation['is-published'] && this.languageType === 'published') {
+        promises.push({
+          type: LanguageTypeEnum.draft,
+          translation,
+        });
+      } else if (
+        !translation['is-published'] &&
+        this.languageType === 'drafts'
+      ) {
+        promises.push({
+          type: LanguageTypeEnum.publish,
+          translation,
+        });
+      }
+    });
+
+    // Call promises
+    if (promises.length) {
+      if (this.languageType === 'published') {
+        this.renderMessage(MessageType.alert, 'Creating drafts...');
+      } else {
+        this.renderMessage(MessageType.success, 'Publishing drafts...');
+      }
+
+      const results: PromisePayload[] = await Promise.all(
+        promises.map(({ type, translation }) => {
+          if (type === LanguageTypeEnum.draft) {
+            return this.draftService
+              .createDraft(translation)
+              .then((value) => ({
+                success: true,
+                type,
+                value,
+              }))
+              .catch((error) => ({
+                success: false,
+                type,
+                error,
+              }));
+          } else {
+            return this.draftService
+              .publishDraft(this.resource, translation)
+              .then((value) => ({
+                success: true,
+                type,
+                value,
+              }))
+              .catch((error) => ({
+                success: false,
+                type,
+                error,
+              }));
           }
-        })
-        .catch((message) => {
-          this.saving = false;
-          this.errorMessage = message;
+        }),
+      );
+
+      // Determine results
+      const invalidResults = results.filter((result) => !result.success);
+      if (invalidResults.length) {
+        invalidResults.forEach((invalidResult) => {
+          this.errorMessage = [...this.errorMessage, invalidResult.error];
+        });
+      } else {
+        if (this.languageType === 'published') {
+          this.renderMessage(MessageType.alert, '');
+          this.renderMessage(
+            MessageType.success,
+            'Drafts created. Ready for you to publish.',
+          );
+          // Update languages
+          this.resourceService
+            .getResources('latest-drafts-translations')
+            .then((resources) => {
+              const resource = resources.find((r) => r.id === this.resource.id);
+              this.setResourceAndLoadTranslations(resource);
+            });
+          setTimeout(() => {
+            this.renderMessage(MessageType.success, '');
+          }, 5000);
+        } else {
+          const publishingErrors = results.filter(
+            (result) => result.value[0]['publishing-errors'],
+          );
+          if (publishingErrors.length) {
+            publishingErrors.forEach((publishingError) => {
+              this.errorMessage = [...this.errorMessage, publishingError.error];
+            });
+          }
+          this.checkToEnsureDraftIsPublished = window.setInterval(() => {
+            this.isDraftPublished();
+          }, 5000);
+        }
+      }
+    }
+  }
+
+  isDraftPublished() {
+    this.resourceService
+      .getResources('latest-drafts-translations')
+      .then((resources) => {
+        const resource = resources.find((r) => r.id === this.resource.id);
+        let numberPubblished = 0;
+        this.translations.forEach((translation) => {
+          const updatedTranslation = resource[
+            'latest-drafts-translations'
+          ].find((t) => t.id === translation.id);
+          if (updatedTranslation) {
+            numberPubblished++;
+          }
+        });
+
+        if (numberPubblished === this.translations.length) {
+          clearInterval(this.checkToEnsureDraftIsPublished);
+          this.renderMessage(
+            MessageType.success,
+            'Drafts are successfully published.',
+          );
+          this.setResourceAndLoadTranslations(resource);
+        }
+      })
+      .catch((err) => {
+        console.log('ERROR', err);
+      });
+  }
+
+  private setResourceAndLoadTranslations(resource: Resource): void {
+    this.resource = resource;
+    this.resource['latest-drafts-translations'].forEach((translation) => {
+      this.languageService
+        .getLanguage(translation.language.id, 'custom_pages,custom_tips')
+        .then((language) => {
+          translation.language = language;
+          translation.is_published = translation['is-published'];
         });
     });
   }

--- a/src/app/components/multiple-draft-generator/multiple-draft-generator.component.ts
+++ b/src/app/components/multiple-draft-generator/multiple-draft-generator.component.ts
@@ -181,12 +181,12 @@ export class MultipleDraftGeneratorComponent implements OnDestroy {
         this.disableButtons = false;
       } else {
         if (this.actionType === 'publish') {
-          const publishingErrors = results.filter(
-            (result) => result.value[0]['publishing-errors'],
-          );
+          const publishingErrors = results
+            .filter((result) => result.value[0]['publishing-errors'])
+            .map((result) => result.value[0]['publishing-errors']);
           if (publishingErrors.length) {
             publishingErrors.forEach((publishingError) => {
-              this.errorMessage = [...this.errorMessage, publishingError.error];
+              this.errorMessage = [...this.errorMessage, publishingError];
             });
           }
           this.checkToEnsureTranslationIsPublished = window.setInterval(() => {

--- a/src/app/components/resource/resource.component.html
+++ b/src/app/components/resource/resource.component.html
@@ -28,7 +28,7 @@
         class="btn btn-secondary"
         *ngIf="!isMetaTool()"
       >
-        <i class="fa fa-plus"></i> Generate multiple drafts
+        <i class="fa fa-plus"></i> Bulk Actions
       </button>
     </div>
   </div>

--- a/src/app/components/translation/translation-version-badge/translation-version-badge.component.html
+++ b/src/app/components/translation/translation-version-badge/translation-version-badge.component.html
@@ -1,9 +1,16 @@
 <span
   class="badge badge-secondary"
-  *ngIf="!translation.is_published && !translation.none"
+  *ngIf="
+    !translation.is_published &&
+    !translation.none &&
+    !translation['publishing-errors']
+  "
   >{{ translation.version }} | Draft</span
 >
 <span class="badge badge-success" *ngIf="translation.is_published"
   >{{ translation.version }} | Live</span
+>
+<span class="badge badge-danger" *ngIf="translation['publishing-errors']"
+  >1 | Error</span
 >
 <span class="badge badge-warning" *ngIf="translation.none">None</span>

--- a/src/app/components/translation/translation-version-badge/translation-version-badge.component.html
+++ b/src/app/components/translation/translation-version-badge/translation-version-badge.component.html
@@ -11,6 +11,6 @@
   >{{ translation.version }} | Live</span
 >
 <span class="badge badge-danger" *ngIf="translation['publishing-errors']"
-  >1 | Error</span
+  >{{ translation.version }} | Error</span
 >
 <span class="badge badge-warning" *ngIf="translation.none">None</span>

--- a/src/app/components/translation/translation.component.html
+++ b/src/app/components/translation/translation.component.html
@@ -52,7 +52,7 @@
       <button
         *ngIf="!translation.is_published && !translation.none"
         type="button"
-        (click)="publishDraft()"
+        (click)="publishOrCreateDraft()"
         class="btn btn-success"
       >
         <i class="fa fa-cloud-upload"></i> Publish
@@ -68,11 +68,11 @@
   </div>
 </div>
 
-<ngb-alert type="success" [dismissible]="false" *ngIf="publishing">
-  Publishing...
+<ngb-alert type="success" [dismissible]="false" *ngIf="sucessfulMessage">
+  {{ sucessfulMessage }}
 </ngb-alert>
-<ngb-alert type="info" [dismissible]="false" *ngIf="saving">
-  Saving...
+<ngb-alert type="info" [dismissible]="false" *ngIf="alertMessage">
+  {{ alertMessage }}
 </ngb-alert>
 <ngb-alert type="danger" [dismissible]="false" *ngIf="errorMessage">
   {{ errorMessage }}

--- a/src/app/components/translation/translation.component.html
+++ b/src/app/components/translation/translation.component.html
@@ -38,7 +38,7 @@
       </button>
     </div>
 
-    <div class="btn-group" role="group">
+    <div class="btn-group mr-2" role="group">
       <button (click)="openResourceLanguage()" class="btn btn-primary">
         <i class="fa fa-pencil"></i> Details
       </button>
@@ -49,20 +49,10 @@
       >
         <i class="fa fa-download"></i> Download
       </a>
-      <button
-        *ngIf="!translation.is_published && !translation.none"
-        type="button"
-        (click)="publishOrCreateDraft()"
-        class="btn btn-success"
-      >
+    </div>
+    <div class="btn-group" role="group">
+      <button type="button" (click)="publish()" class="btn btn-success">
         <i class="fa fa-cloud-upload"></i> Publish
-      </button>
-      <button
-        *ngIf="translation.is_published || translation.none"
-        (click)="createDraft()"
-        class="btn btn-secondary"
-      >
-        <i class="fa fa-plus"></i> New Draft
       </button>
     </div>
   </div>

--- a/src/app/components/translation/translation.component.ts
+++ b/src/app/components/translation/translation.component.ts
@@ -50,6 +50,7 @@ export class TranslationComponent implements OnInit, OnChanges, OnDestroy {
   alertMessage: string;
   sucessfulMessage: string;
   checkToEnsureDraftIsPublished: number;
+  successfullyPublishedMessage = 'Language has been successfully published.';
 
   constructor(
     private customPageService: CustomPageService,
@@ -194,12 +195,13 @@ export class TranslationComponent implements OnInit, OnChanges, OnDestroy {
             this.renderMessage(MessageType.error, null);
             this.renderMessage(
               MessageType.success,
-              'Language has been successfully published.',
+              this.successfullyPublishedMessage,
             );
             this.loadAllResources();
           }
         });
     } catch (err) {
+      console.log('ERROR', err);
       clearInterval(this.checkToEnsureDraftIsPublished);
       this.renderMessage(MessageType.success, null);
       this.renderMessage(MessageType.error, err.message);

--- a/src/app/models/message.ts
+++ b/src/app/models/message.ts
@@ -1,0 +1,5 @@
+export enum MessageType {
+  success = 'sucessful',
+  alert = 'alert',
+  error = 'error',
+}

--- a/src/app/models/translation.ts
+++ b/src/app/models/translation.ts
@@ -9,7 +9,7 @@ export class Translation {
   resource: Resource;
   version: number;
 
-  generateDraft: boolean;
+  selectedForAction: boolean;
   none: boolean;
 
   static copy(translation: Translation): Translation {

--- a/src/app/service/draft.service.ts
+++ b/src/app/service/draft.service.ts
@@ -7,10 +7,12 @@ import { Page } from '../models/page';
 import { Tip } from '../models/tip';
 import { environment } from '../../environments/environment';
 import { AbstractService } from './abstract.service';
+import { Resource } from '../models/resource';
 
 @Injectable()
 export class DraftService extends AbstractService {
   private readonly draftsUrl = environment.base_url + 'drafts';
+  private readonly resourcesUrl = environment.base_url + 'resources';
 
   constructor(private http: Http, private authService: AuthService) {
     super();
@@ -59,19 +61,29 @@ export class DraftService extends AbstractService {
       .catch(this.handleError);
   }
 
-  updateDraft(translation: Translation): Promise<Translation> {
+  publishDraft(
+    resource: Resource,
+    translation: Translation,
+  ): Promise<Translation> {
     const payload = {
       data: {
-        type: 'translation',
-        attributes: {
-          is_published: translation.is_published,
+        type: 'publish-translations',
+        relationships: {
+          languages: {
+            data: [
+              {
+                id: translation.language.id,
+                type: 'language',
+              },
+            ],
+          },
         },
       },
     };
 
     return this.http
-      .put(
-        `${this.draftsUrl}/${translation.id}`,
+      .post(
+        `${this.resourcesUrl}/${resource.id}/translations/publish`,
         payload,
         this.authService.getAuthorizationAndOptions(),
       )

--- a/src/app/service/resource/resource.service.spec.ts
+++ b/src/app/service/resource/resource.service.spec.ts
@@ -59,17 +59,35 @@ describe('ResourceService', () => {
     expect(mockHttp.put).toHaveBeenCalledWith(anything(), anything(), headers);
   });
 
-  it('should not include "include"', () => {
-    service.getResource(resource.id);
-    expect(mockHttp.get).toHaveBeenCalledWith(
-      `${environment.base_url}resources/${resource.id}`,
-    );
+  describe('GetResources()', () => {
+    it('should include "include"', () => {
+      service.getResources('test-data');
+      expect(mockHttp.get).toHaveBeenCalledWith(
+        `${environment.base_url}resources?include=test-data`,
+      );
+    });
+
+    it('should not include "include"', () => {
+      service.getResource(resource.id);
+      expect(mockHttp.get).toHaveBeenCalledWith(
+        `${environment.base_url}resources/${resource.id}`,
+      );
+    });
   });
 
-  it('should include "include"', () => {
-    service.getResource(resource.id, 'test-data');
-    expect(mockHttp.get).toHaveBeenCalledWith(
-      `${environment.base_url}resources/${resource.id}?include=test-data`,
-    );
+  describe('GetResource()', () => {
+    it('should include "include"', () => {
+      service.getResource(resource.id, 'test-data');
+      expect(mockHttp.get).toHaveBeenCalledWith(
+        `${environment.base_url}resources/${resource.id}?include=test-data`,
+      );
+    });
+
+    it('should not include "include"', () => {
+      service.getResource(resource.id);
+      expect(mockHttp.get).toHaveBeenCalledWith(
+        `${environment.base_url}resources/${resource.id}`,
+      );
+    });
   });
 });

--- a/src/app/service/resource/resource.service.spec.ts
+++ b/src/app/service/resource/resource.service.spec.ts
@@ -4,6 +4,8 @@ import { Http, RequestOptionsArgs } from '@angular/http';
 import { AuthService } from '../auth/auth.service';
 import { Resource } from '../../models/resource';
 import { Observable } from 'rxjs/Observable';
+import { environment } from '../../../environments/environment';
+
 import anything = jasmine.anything;
 
 const headers: RequestOptionsArgs = {};
@@ -16,12 +18,13 @@ class MockAuthService extends AuthService {
   }
 }
 
-describe('ResourceService', () => {
+fdescribe('ResourceService', () => {
   const mockHttp = new MockHttp(null, null);
   const mockAuthService = new MockAuthService(null, null);
   const service = new ResourceService(mockHttp, mockAuthService);
 
   const resource = new Resource();
+  resource.id = 13;
 
   beforeEach(() => {
     spyOn(mockHttp, 'post').and.returnValue(
@@ -38,6 +41,10 @@ describe('ResourceService', () => {
     spyOn(mockHttp, 'put').and.returnValue(
       new Observable((observer) => observer.complete()),
     );
+
+    spyOn(mockHttp, 'get').and.returnValue(
+      new Observable((observer) => observer.complete()),
+    );
   });
 
   it('creating uses authorization code', () => {
@@ -50,5 +57,15 @@ describe('ResourceService', () => {
     service.update(resource);
 
     expect(mockHttp.put).toHaveBeenCalledWith(anything(), anything(), headers);
+  });
+
+  it('should not include "include"', () => {
+    service.getResource(resource.id);
+    expect(mockHttp.get).toHaveBeenCalledWith(`${environment.base_url}resources/${resource.id}`);
+  });
+
+  it('should include "include"', () => {
+    service.getResource(resource.id, 'test-data');
+    expect(mockHttp.get).toHaveBeenCalledWith(`${environment.base_url}resources/${resource.id}?include=test-data`);
   });
 });

--- a/src/app/service/resource/resource.service.spec.ts
+++ b/src/app/service/resource/resource.service.spec.ts
@@ -18,7 +18,7 @@ class MockAuthService extends AuthService {
   }
 }
 
-fdescribe('ResourceService', () => {
+describe('ResourceService', () => {
   const mockHttp = new MockHttp(null, null);
   const mockAuthService = new MockAuthService(null, null);
   const service = new ResourceService(mockHttp, mockAuthService);
@@ -61,11 +61,15 @@ fdescribe('ResourceService', () => {
 
   it('should not include "include"', () => {
     service.getResource(resource.id);
-    expect(mockHttp.get).toHaveBeenCalledWith(`${environment.base_url}resources/${resource.id}`);
+    expect(mockHttp.get).toHaveBeenCalledWith(
+      `${environment.base_url}resources/${resource.id}`,
+    );
   });
 
   it('should include "include"', () => {
     service.getResource(resource.id, 'test-data');
-    expect(mockHttp.get).toHaveBeenCalledWith(`${environment.base_url}resources/${resource.id}?include=test-data`);
+    expect(mockHttp.get).toHaveBeenCalledWith(
+      `${environment.base_url}resources/${resource.id}?include=test-data`,
+    );
   });
 });

--- a/src/app/service/resource/resource.service.ts
+++ b/src/app/service/resource/resource.service.ts
@@ -30,7 +30,9 @@ export class ResourceService extends AbstractService {
   getResource(resourceId: number, include?: string): Promise<Resource> {
     return this.http
       .get(
-        include ? `${this.resourcesUrl}/${resourceId}?include=${include}` : `${this.resourcesUrl}/${resourceId}`,
+        include
+          ? `${this.resourcesUrl}/${resourceId}?include=${include}`
+          : `${this.resourcesUrl}/${resourceId}`,
       )
       .toPromise()
       .then((response) => {

--- a/src/app/service/resource/resource.service.ts
+++ b/src/app/service/resource/resource.service.ts
@@ -27,6 +27,18 @@ export class ResourceService extends AbstractService {
       .catch(this.handleError);
   }
 
+  getResource(resourceId: number, include?: string): Promise<Resource> {
+    return this.http
+      .get(
+        include ? `${this.resourcesUrl}/${resourceId}?include=${include}` : `${this.resourcesUrl}/${resourceId}`,
+      )
+      .toPromise()
+      .then((response) => {
+        return new JsonApiDataStore().sync(response.json());
+      })
+      .catch(this.handleError);
+  }
+
   create(resource: Resource): Promise<Resource> {
     return this.http
       .post(


### PR DESCRIPTION
## Description
Added new async publish API endpoint to single and bulk calls. I've also updated the "Bulk actions" modal by allowing bulk create drafts and bulk publish drafts.

### On single publish
- We have changed it to one button which either creates the Draft or publishes the draft.
- If Create draft, this works as it previously did.
- If publish a draft, we hit the new publish endpoint and watch for changes every 5 seconds. We also show the publishing errors if there are any.

### Bulk:
- I updated how we're sending calls to the API to call promises, so we can check if any errors happen to any calls.
- Bulk drafts are the same apart from using the new promises functionality. 
- I also updated the UI and messaging.
- Bulk publish, for each publish we hit the publish endpoint and watch for errors and publishing errors. If any we report them to the user. We then watch to ensure the languages are published. When they are, we notify the user. If there are publish errors, we also notify the user.
- After any bulk action, we don't close out the modal, but we now update the languages.



### Test:
- Need to test publishing errors (I haven't had any errors as of yet)
- I also need to write the tests for this functionality.
- Tests aren't currently working due to a TS error.

I'm going to be out until Jan 8th from today, so I wanted this PR to be up for you to review. However, since I did it in a bit of a rush, I hope there aren't many errors, but there might be some.
